### PR TITLE
chore: setup workspace-wide edition and license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["core", "utils", "discord", "irc", "app", "testing"]
 resolver = "2"
+
+[workspace.package]
+edition = "2024"
+license = "AGPL-3.0"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bridge"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "bridge"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bridge-core"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 http = "1"

--- a/discord/Cargo.toml
+++ b/discord/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bridge-discord"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bridge-core = { path = "../core" }

--- a/irc/Cargo.toml
+++ b/irc/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bridge-irc"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bridge-core = { path = "../core" }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "bridge-testing"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 bridge-core = { path = "../core" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
 name = "bridge-utils"
 version = "0.1.0"
-edition = "2024"
+edition.workspace = true
+license.workspace = true


### PR DESCRIPTION
This PR setups a workspace-wide values for `edition` and `license`.
As far as I know, it is not that common to have crates in a monorepo using different licenses and rust editions