### PR TITLE
fix: graceful shutdown

### DIFF
--- a/core/src/adapter.rs
+++ b/core/src/adapter.rs
@@ -1,5 +1,7 @@
 //! Lifecycle contract for platform crates
 
+use std::sync::Arc;
+
 use exn::Exn;
 use tokio::sync::{mpsc, oneshot};
 
@@ -10,9 +12,9 @@ pub struct PlatformHandle {
     pub id: PlatformId,
     // TODO: Maybe have the capabilities boxed into one thing
     //       Once we have many of them it will become clumbersome
-    pub sender: Box<dyn SendMessage>,
-    pub user_lister: Box<dyn ListUsers>,
-    pub channel_lister: Box<dyn ListChannels>,
+    pub sender: Arc<dyn SendMessage>,
+    pub user_lister: Arc<dyn ListUsers>,
+    pub channel_lister: Arc<dyn ListChannels>,
     pub shutdown_tx: oneshot::Sender<()>,
 }
 

--- a/core/src/capabilities/list_channels.rs
+++ b/core/src/capabilities/list_channels.rs
@@ -1,9 +1,15 @@
 //! Listing channels known to a platform.
 
-use exn::Exn;
+use {exn::Exn, std::sync::Arc};
 
 use crate::{BoxFuture, HarmonyError, PlatformChannel};
 
 pub trait ListChannels: Send + Sync {
     fn list_channels(&self) -> BoxFuture<'_, Result<Vec<PlatformChannel>, Exn<HarmonyError>>>;
+}
+
+impl<T: ListChannels> ListChannels for Arc<T> {
+    fn list_channels(&self) -> BoxFuture<'_, Result<Vec<PlatformChannel>, Exn<HarmonyError>>> {
+        (**self).list_channels()
+    }
 }

--- a/core/src/capabilities/list_channels.rs
+++ b/core/src/capabilities/list_channels.rs
@@ -1,4 +1,5 @@
 //! Listing channels known to a platform.
+use std::sync::Arc;
 
 use exn::Exn;
 
@@ -6,4 +7,10 @@ use crate::{BoxFuture, HarmonyError, PlatformChannel};
 
 pub trait ListChannels: Send + Sync {
     fn list_channels(&self) -> BoxFuture<'_, Result<Vec<PlatformChannel>, Exn<HarmonyError>>>;
+}
+
+impl<T: ListChannels> ListChannels for Arc<T> {
+    fn list_channels(&self) -> BoxFuture<'_, Result<Vec<PlatformChannel>, Exn<HarmonyError>>> {
+        (**self).list_channels()
+    }
 }

--- a/core/src/capabilities/list_users.rs
+++ b/core/src/capabilities/list_users.rs
@@ -1,9 +1,15 @@
 //! Listing users known to a platform.
 
-use exn::Exn;
+use {exn::Exn, std::sync::Arc};
 
 use crate::{BoxFuture, HarmonyError, PlatformUser};
 
 pub trait ListUsers: Send + Sync {
     fn list_users(&self) -> BoxFuture<'_, Result<Vec<PlatformUser>, Exn<HarmonyError>>>;
+}
+
+impl<T: ListUsers> ListUsers for Arc<T> {
+    fn list_users(&self) -> BoxFuture<'_, Result<Vec<PlatformUser>, Exn<HarmonyError>>> {
+        (**self).list_users()
+    }
 }

--- a/core/src/capabilities/list_users.rs
+++ b/core/src/capabilities/list_users.rs
@@ -1,9 +1,17 @@
 //! Listing users known to a platform.
 
+use std::sync::Arc;
+
 use exn::Exn;
 
 use crate::{BoxFuture, HarmonyError, PlatformUser};
 
 pub trait ListUsers: Send + Sync {
     fn list_users(&self) -> BoxFuture<'_, Result<Vec<PlatformUser>, Exn<HarmonyError>>>;
+}
+
+impl<T: ListUsers> ListUsers for Arc<T> {
+    fn list_users(&self) -> BoxFuture<'_, Result<Vec<PlatformUser>, Exn<HarmonyError>>> {
+        (**self).list_users()
+    }
 }

--- a/core/src/capabilities/send_message.rs
+++ b/core/src/capabilities/send_message.rs
@@ -1,14 +1,21 @@
 //! Sending a message to a target channel.
 
-use exn::Exn;
+use {exn::Exn, std::sync::Arc};
 
-use crate::BoxFuture;
-use crate::CoreMessage;
-use crate::HarmonyError;
+use crate::{BoxFuture, CoreMessage, HarmonyError};
 
 pub trait SendMessage: Send + Sync + 'static {
     fn send_message<'a>(
         &'a self,
         message: &'a CoreMessage,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>>;
+}
+
+impl<T: SendMessage> SendMessage for Arc<T> {
+    fn send_message<'a>(
+        &'a self,
+        message: &'a CoreMessage,
+    ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
+        (**self).send_message(message)
+    }
 }

--- a/core/src/capabilities/send_message.rs
+++ b/core/src/capabilities/send_message.rs
@@ -1,21 +1,14 @@
 //! Sending a message to a target channel.
 
-use {exn::Exn, std::sync::Arc};
+use std::sync::Arc;
+
+use exn::Exn;
 
 use crate::{BoxFuture, CoreMessage, HarmonyError};
 
 pub trait SendMessage: Send + Sync + 'static {
     fn send_message<'a>(
         &'a self,
-        message: &'a CoreMessage,
+        message: &'a Arc<CoreMessage>,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>>;
-}
-
-impl<T: SendMessage> SendMessage for Arc<T> {
-    fn send_message<'a>(
-        &'a self,
-        message: &'a CoreMessage,
-    ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
-        (**self).send_message(message)
-    }
 }

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -1,12 +1,14 @@
 //! Lifecycle: start adapters, discover data, relay messages, handle events.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use exn::{Exn, ResultExt as _};
-use tokio::sync::{RwLock, mpsc, oneshot};
-use tokio::task::JoinHandle;
+use {
+    exn::{Exn, ResultExt as _},
+    tokio::{
+        sync::{RwLock, mpsc, oneshot},
+        task::JoinHandle,
+    },
+};
 
 use crate::error::HarmonyError;
 
@@ -105,7 +107,7 @@ pub async fn run(
     drop(msg_tx);
     drop(event_tx);
 
-    let (channels, users) = discover_and_build(&channel_listers, &user_listers).await;
+    let (channels, users) = discover_and_build(channel_listers, user_listers).await;
 
     log::info!(
         "Harmony ready: {} channel bridge(s), {} user group(s)",
@@ -186,8 +188,8 @@ async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessag
 
 /// Query all adapters for their channels/users, then build the collections.
 async fn discover_and_build(
-    channel_listers: &HashMap<PlatformId, Box<dyn ListChannels>>,
-    user_listers: &HashMap<PlatformId, Box<dyn ListUsers>>,
+    channel_listers: HashMap<PlatformId, Box<dyn ListChannels>>,
+    user_listers: HashMap<PlatformId, Box<dyn ListUsers>>,
 ) -> (Channels, Users) {
     let mut discovered_channels = Vec::new();
     for (pid, lister) in channel_listers {

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -105,7 +105,7 @@ pub async fn run(
     drop(msg_tx);
     drop(event_tx);
 
-    let (channels, users) = discover_and_build(&channel_listers, &user_listers).await;
+    let (channels, users) = discover_and_build(channel_listers, user_listers).await;
 
     log::info!(
         "Harmony ready: {} channel bridge(s), {} user group(s)",
@@ -224,8 +224,8 @@ async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessag
 
 /// Query all adapters for their channels/users, then build the collections.
 async fn discover_and_build(
-    channel_listers: &HashMap<PlatformId, Box<dyn ListChannels>>,
-    user_listers: &HashMap<PlatformId, Box<dyn ListUsers>>,
+    channel_listers: HashMap<PlatformId, Box<dyn ListChannels>>,
+    user_listers: HashMap<PlatformId, Box<dyn ListUsers>>,
 ) -> (Channels, Users) {
     let mut discovered_channels = Vec::new();
     for (pid, lister) in channel_listers {

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -22,14 +22,14 @@ use crate::{
 pub(crate) struct CoreCtx {
     pub(crate) channels: Arc<RwLock<Peers<CoreChannel>>>,
     pub(crate) users: Arc<RwLock<Peers<CoreUser>>>,
-    pub(crate) senders: HashMap<PlatformId, Box<dyn SendMessage>>,
+    pub(crate) senders: HashMap<PlatformId, Arc<dyn SendMessage>>,
 }
 
 impl CoreCtx {
     pub(crate) fn new(
         channels: Arc<RwLock<Peers<CoreChannel>>>,
         users: Arc<RwLock<Peers<CoreUser>>>,
-        senders: HashMap<PlatformId, Box<dyn SendMessage>>,
+        senders: HashMap<PlatformId, Arc<dyn SendMessage>>,
     ) -> Self {
         Self {
             channels,
@@ -72,9 +72,9 @@ pub async fn run(
         mpsc::channel::<(PlatformId, PlatformMessage)>(DEFAULT_CHANNEL_BUFFER);
     let (event_tx, mut event_rx) = mpsc::channel::<MetaEvent>(DEFAULT_CHANNEL_BUFFER);
 
-    let mut senders: HashMap<PlatformId, Box<dyn SendMessage>> = HashMap::new();
-    let mut user_listers: HashMap<PlatformId, Box<dyn ListUsers>> = HashMap::new();
-    let mut channel_listers: HashMap<PlatformId, Box<dyn ListChannels>> = HashMap::new();
+    let mut senders: HashMap<PlatformId, Arc<dyn SendMessage>> = HashMap::new();
+    let mut user_listers: HashMap<PlatformId, Arc<dyn ListUsers>> = HashMap::new();
+    let mut channel_listers: HashMap<PlatformId, Arc<dyn ListChannels>> = HashMap::new();
     let mut shutdown_txs: Vec<(PlatformId, oneshot::Sender<()>)> = Vec::new();
 
     let start_futures: Vec<_> = adapters
@@ -224,8 +224,8 @@ async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessag
 
 /// Query all adapters for their channels/users, then build the collections.
 async fn discover_and_build(
-    channel_listers: HashMap<PlatformId, Box<dyn ListChannels>>,
-    user_listers: HashMap<PlatformId, Box<dyn ListUsers>>,
+    channel_listers: HashMap<PlatformId, Arc<dyn ListChannels>>,
+    user_listers: HashMap<PlatformId, Arc<dyn ListUsers>>,
 ) -> (Channels, Users) {
     let mut discovered_channels = Vec::new();
     for (pid, lister) in channel_listers {

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -189,11 +189,11 @@ async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessag
         resolve_or_register(&mut u, source_id, &msg.author)
     };
 
-    let core_msg = CoreMessage {
+    let core_msg = Arc::new(CoreMessage {
         author: core_author,
         channel: core_channel.clone(),
         content: platform_to_core_message(&ctx, source_id, msg.content).await,
-    };
+    });
 
     for platform in core_channel.alias.keys() {
         if platform == source_id {

--- a/discord/src/adapter.rs
+++ b/discord/src/adapter.rs
@@ -1,13 +1,18 @@
 //! Starts a Serenity client, produces a `PlatformHandle`.
-
-use exn::{Exn, ResultExt as _};
-use harmony_core::{
-    BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
-    PlatformMessage,
+use crate::{
+    proxy::{DiscordSendProxy, SendRequest},
+    sender::DiscordSender,
 };
-use tokio::sync::{mpsc, oneshot};
 
-use crate::sender::DiscordSender;
+use {
+    exn::{Exn, ResultExt as _},
+    harmony_core::{
+        BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
+        PlatformMessage, SendMessage,
+    },
+    std::sync::Arc,
+    tokio::sync::{mpsc, oneshot},
+};
 
 pub struct DiscordAdapter {
     token: String,
@@ -54,8 +59,8 @@ impl PlatformAdapter for DiscordAdapter {
                 .await
                 .or_raise(|| HarmonyError::connection("discord client setup failed"))?;
 
-            let http = client.http.clone();
-            let shard_manager = client.shard_manager.clone();
+            let shard_manager = Arc::clone(&client.shard_manager);
+            let http = Arc::clone(&client.http);
             let sender = DiscordSender::new(http, platform_id.clone());
 
             let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -66,17 +71,32 @@ impl PlatformAdapter for DiscordAdapter {
                 }
             });
 
+            let lister = Arc::new(sender.clone());
+
             let sm = shard_manager;
+            let (send_tx, mut send_rx) = mpsc::channel(256);
             tokio::spawn(async move {
-                let _ = shutdown_rx.await;
-                sm.shutdown_all().await;
+                let mut shutdown = shutdown_rx;
+                loop {
+                    tokio::select! {
+                        req = send_rx.recv() => {
+                            let Some(req) : Option<SendRequest> = req else { break };
+                            let result = sender.send_message(&req.message).await;
+                            let _ = req.response_tx.send(result);
+                        }
+                        _ = &mut shutdown => {
+                            sm.shutdown_all().await;
+                            break;
+                        }
+                    }
+                }
             });
 
             Ok(PlatformHandle {
                 id: platform_id,
-                sender: Box::new(sender.clone()),
-                user_lister: Box::new(sender.clone()),
-                channel_lister: Box::new(sender),
+                sender: Box::new(DiscordSendProxy { tx: send_tx }),
+                user_lister: Box::new(Arc::clone(&lister)),
+                channel_lister: Box::new(lister),
                 shutdown_tx,
             })
         })

--- a/discord/src/adapter.rs
+++ b/discord/src/adapter.rs
@@ -1,13 +1,12 @@
 //! Starts a Serenity client, produces a `PlatformHandle`.
 
-
 use std::sync::Arc;
 
 use exn::{Exn, ResultExt as _};
 use harmony_core::{
-        BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
-        PlatformMessage, SendMessage,
-    };
+    BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
+    PlatformMessage, SendMessage,
+};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::proxy::{DiscordSendProxy, SendRequest};
@@ -93,9 +92,9 @@ impl PlatformAdapter for DiscordAdapter {
 
             Ok(PlatformHandle {
                 id: platform_id,
-                sender: Box::new(DiscordSendProxy { tx: send_tx }),
-                user_lister: Box::new(Arc::clone(&lister)),
-                channel_lister: Box::new(lister),
+                sender: Arc::new(DiscordSendProxy { tx: send_tx }),
+                user_lister: Arc::clone(&lister) as Arc<dyn harmony_core::ListUsers>,
+                channel_lister: Arc::new(lister),
                 shutdown_tx,
             })
         })

--- a/discord/src/adapter.rs
+++ b/discord/src/adapter.rs
@@ -1,12 +1,16 @@
 //! Starts a Serenity client, produces a `PlatformHandle`.
 
+
+use std::sync::Arc;
+
 use exn::{Exn, ResultExt as _};
 use harmony_core::{
-    BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
-    PlatformMessage,
-};
+        BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformHandle, PlatformId,
+        PlatformMessage, SendMessage,
+    };
 use tokio::sync::{mpsc, oneshot};
 
+use crate::proxy::{DiscordSendProxy, SendRequest};
 use crate::sender::DiscordSender;
 
 pub struct DiscordAdapter {
@@ -54,8 +58,8 @@ impl PlatformAdapter for DiscordAdapter {
                 .await
                 .or_raise(|| HarmonyError::connection("discord client setup failed"))?;
 
-            let http = client.http.clone();
-            let shard_manager = client.shard_manager.clone();
+            let shard_manager = Arc::clone(&client.shard_manager);
+            let http = Arc::clone(&client.http);
             let sender = DiscordSender::new(http, platform_id.clone());
 
             let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
@@ -66,17 +70,32 @@ impl PlatformAdapter for DiscordAdapter {
                 }
             });
 
+            let lister = Arc::new(sender.clone());
+
             let sm = shard_manager;
+            let (send_tx, mut send_rx) = mpsc::channel(256);
             tokio::spawn(async move {
-                let _ = shutdown_rx.await;
-                sm.shutdown_all().await;
+                let mut shutdown = shutdown_rx;
+                loop {
+                    tokio::select! {
+                        req = send_rx.recv() => {
+                            let Some(req) : Option<SendRequest> = req else { break };
+                            let result = sender.send_message(&req.message).await;
+                            let _ = req.response_tx.send(result);
+                        }
+                        _ = &mut shutdown => {
+                            sm.shutdown_all().await;
+                            break;
+                        }
+                    }
+                }
             });
 
             Ok(PlatformHandle {
                 id: platform_id,
-                sender: Box::new(sender.clone()),
-                user_lister: Box::new(sender.clone()),
-                channel_lister: Box::new(sender),
+                sender: Box::new(DiscordSendProxy { tx: send_tx }),
+                user_lister: Box::new(Arc::clone(&lister)),
+                channel_lister: Box::new(lister),
                 shutdown_tx,
             })
         })

--- a/discord/src/lib.rs
+++ b/discord/src/lib.rs
@@ -4,7 +4,7 @@ mod adapter;
 mod convert;
 mod fetch;
 mod handler;
+mod proxy;
 mod sender;
 
 pub use adapter::DiscordAdapter;
-pub use sender::DiscordSender;

--- a/discord/src/proxy.rs
+++ b/discord/src/proxy.rs
@@ -1,0 +1,45 @@
+//! Channel-based proxy for [`SendMessage`] that decouples the core relay loop
+//! from adapter-internal resources.
+
+use {
+    exn::Exn,
+    harmony_core::{BoxFuture, CoreMessage, HarmonyError, SendMessage},
+    tokio::sync::{mpsc, oneshot},
+};
+
+pub(crate) struct SendRequest {
+    pub message: CoreMessage,
+    pub response_tx: oneshot::Sender<Result<(), Exn<HarmonyError>>>,
+}
+
+pub(crate) struct DiscordSendProxy {
+    pub tx: mpsc::Sender<SendRequest>,
+}
+
+impl SendMessage for DiscordSendProxy {
+    fn send_message<'a>(
+        &'a self,
+        message: &'a CoreMessage,
+    ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
+        Box::pin(async {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.tx
+                .send(SendRequest {
+                    message: message.clone(),
+                    response_tx,
+                })
+                .await
+                .map_err(|_| {
+                    Exn::from(
+                        HarmonyError::send("failed to send message to discord adapter").permanent(),
+                    )
+                })?;
+            response_rx.await.map_err(|_| {
+                Exn::from(
+                    HarmonyError::send("failed to received response from discord adapter")
+                        .permanent(),
+                )
+            })?
+        })
+    }
+}

--- a/discord/src/proxy.rs
+++ b/discord/src/proxy.rs
@@ -19,13 +19,13 @@ pub struct DiscordSendProxy {
 impl SendMessage for DiscordSendProxy {
     fn send_message<'a>(
         &'a self,
-        message: &'a CoreMessage,
+        message: &'a Arc<CoreMessage>,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
         Box::pin(async {
             let (response_tx, response_rx) = oneshot::channel();
             self.tx
                 .send(SendRequest {
-                    message: message.clone(),
+                    message: Arc::clone(message),
                     response_tx,
                 })
                 .await

--- a/discord/src/proxy.rs
+++ b/discord/src/proxy.rs
@@ -1,0 +1,45 @@
+//! Channel-based proxy for [`SendMessage`] that decouples the core relay loop
+//! from adapter-internal resources.
+
+use std::sync::Arc;
+
+use exn::Exn;
+use harmony_core::{BoxFuture, CoreMessage, HarmonyError, SendMessage};
+use tokio::sync::{mpsc, oneshot};
+
+pub struct SendRequest {
+    pub message: Arc<CoreMessage>,
+    pub response_tx: oneshot::Sender<Result<(), Exn<HarmonyError>>>,
+}
+
+pub struct DiscordSendProxy {
+    pub tx: mpsc::Sender<SendRequest>,
+}
+
+impl SendMessage for DiscordSendProxy {
+    fn send_message<'a>(
+        &'a self,
+        message: &'a CoreMessage,
+    ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
+        Box::pin(async {
+            let (response_tx, response_rx) = oneshot::channel();
+            self.tx
+                .send(SendRequest {
+                    message: message.clone(),
+                    response_tx,
+                })
+                .await
+                .map_err(|_| {
+                    Exn::from(
+                        HarmonyError::send("failed to send message to discord adapter").permanent(),
+                    )
+                })?;
+            response_rx.await.map_err(|_| {
+                Exn::from(
+                    HarmonyError::send("failed to receive response from discord adapter")
+                        .temporary(),
+                )
+            })?
+        })
+    }
+}

--- a/discord/src/sender.rs
+++ b/discord/src/sender.rs
@@ -1,29 +1,31 @@
 //! Sends bridged messages via per-channel webhooks, and implements listing capabilities.
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use exn::{Exn, OptionExt as _, ResultExt as _};
-use harmony_core::{
-    BoxFuture, CoreMessage, HarmonyError, ListChannels, ListUsers, PlatformChannel, PlatformId,
-    PlatformUser, SendMessage,
+use {
+    exn::{Exn, OptionExt as _, ResultExt as _},
+    harmony_core::{
+        BoxFuture, CoreMessage, HarmonyError, ListChannels, ListUsers, PlatformChannel, PlatformId,
+        PlatformUser, SendMessage,
+    },
+    serenity::{
+        builder::{CreateWebhook, ExecuteWebhook},
+        model::{id::ChannelId, webhook::Webhook},
+    },
+    tokio::sync::RwLock,
 };
-use serenity::builder::{CreateWebhook, ExecuteWebhook};
-use serenity::model::id::ChannelId;
-use serenity::model::webhook::Webhook;
-use tokio::sync::RwLock;
 
 const WEBHOOK_NAME: &str = "Bridge";
 
 #[derive(Clone)]
-pub struct DiscordSender {
+pub(crate) struct DiscordSender {
     pub(crate) http: Arc<serenity::http::Http>,
     pub(crate) platform_id: PlatformId,
     webhooks: Arc<RwLock<HashMap<u64, Webhook>>>,
 }
 
 impl DiscordSender {
-    pub fn new(http: Arc<serenity::http::Http>, platform_id: PlatformId) -> Self {
+    pub(crate) fn new(http: Arc<serenity::http::Http>, platform_id: PlatformId) -> Self {
         Self {
             http,
             platform_id,

--- a/discord/src/sender.rs
+++ b/discord/src/sender.rs
@@ -103,7 +103,7 @@ fn format_message_from_core(platform_id: &PlatformId, message: &CoreMessage) -> 
 impl SendMessage for DiscordSender {
     fn send_message<'a>(
         &'a self,
-        message: &'a CoreMessage,
+        message: &'a Arc<CoreMessage>,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
         Box::pin(async move {
             let channel = message

--- a/discord/src/sender.rs
+++ b/discord/src/sender.rs
@@ -9,9 +9,10 @@ use harmony_core::{
     BoxFuture, CoreMessage, CoreMessageSegment, HarmonyError, ListChannels, ListUsers,
     PlatformChannel, PlatformId, PlatformUser, SendMessage,
 };
-use serenity::builder::{CreateWebhook, ExecuteWebhook};
-use serenity::model::id::ChannelId;
-use serenity::model::webhook::Webhook;
+use serenity::{
+    builder::{CreateWebhook, ExecuteWebhook},
+    model::{id::ChannelId, webhook::Webhook},
+};
 use tokio::sync::RwLock;
 
 use crate::convert::format_mention;
@@ -26,7 +27,7 @@ pub struct DiscordSender {
 }
 
 impl DiscordSender {
-    pub fn new(http: Arc<serenity::http::Http>, platform_id: PlatformId) -> Self {
+    pub(crate) fn new(http: Arc<serenity::http::Http>, platform_id: PlatformId) -> Self {
         Self {
             http,
             platform_id,

--- a/irc/src/adapter.rs
+++ b/irc/src/adapter.rs
@@ -1,20 +1,21 @@
 //! Connects to IRC, spawns the message stream, produces a `PlatformHandle`.
 
-use std::collections::HashSet;
-use std::time::Duration;
-
-use exn::{Exn, ResultExt as _};
-use futures::prelude::*;
-use harmony_core::{
-    BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformChannel, PlatformHandle,
-    PlatformId, PlatformMessage, PlatformUser,
+use {
+    exn::{Exn, ResultExt as _},
+    futures::prelude::*,
+    harmony_core::{
+        BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformChannel, PlatformHandle,
+        PlatformId, PlatformMessage, PlatformUser,
+    },
+    irc::{
+        client::{Client, ClientStream, Sender as RawSender},
+        proto::{Command, Response},
+    },
+    std::{collections::HashSet, sync::Arc, time::Duration},
+    tokio::sync::{mpsc, oneshot},
 };
-use irc::client::{Client, ClientStream, Sender as RawSender};
-use irc::proto::{Command, Response};
-use tokio::sync::{mpsc, oneshot};
 
-use crate::lister::IrcLister;
-use crate::sender::IrcSender;
+use crate::{lister::IrcLister, sender::IrcSender};
 
 pub use irc::client::data::Config as IrcConfig;
 
@@ -85,10 +86,12 @@ impl PlatformAdapter for IrcAdapter {
                 }
             });
 
+            let lister = Arc::new(lister);
+
             Ok(PlatformHandle {
                 id: platform_id,
                 sender: Box::new(sender),
-                user_lister: Box::new(lister.clone()),
+                user_lister: Box::new(Arc::clone(&lister)),
                 channel_lister: Box::new(lister),
                 shutdown_tx,
             })

--- a/irc/src/adapter.rs
+++ b/irc/src/adapter.rs
@@ -1,6 +1,7 @@
 //! Connects to IRC, spawns the message stream, produces a `PlatformHandle`.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 use std::time::Duration;
 
 use exn::{Exn, ResultExt as _};
@@ -9,12 +10,13 @@ use harmony_core::{
     BoxFuture, HarmonyError, MetaEvent, PlatformAdapter, PlatformChannel, PlatformHandle,
     PlatformId, PlatformMessage, PlatformUser,
 };
-use irc::client::{Client, ClientStream, Sender as RawSender};
-use irc::proto::{Command, Response};
+use irc::{
+    client::{Client, ClientStream, Sender as RawSender},
+    proto::{Command, Response},
+};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::lister::IrcLister;
-use crate::sender::IrcSender;
+use crate::{lister::IrcLister, sender::IrcSender};
 
 pub use irc::client::data::Config as IrcConfig;
 
@@ -70,8 +72,6 @@ impl PlatformAdapter for IrcAdapter {
             let (channels, users) =
                 discover_and_join(&raw_sender, &mut stream, &platform_id, &bot_nickname).await;
 
-            let lister = IrcLister { channels, users };
-
             let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
             let pid = platform_id.clone();
             let bn = bot_nickname;
@@ -85,10 +85,12 @@ impl PlatformAdapter for IrcAdapter {
                 }
             });
 
+            let lister = Arc::new(IrcLister { channels, users });
+
             Ok(PlatformHandle {
                 id: platform_id,
                 sender: Box::new(sender),
-                user_lister: Box::new(lister.clone()),
+                user_lister: Box::new(Arc::clone(&lister)),
                 channel_lister: Box::new(lister),
                 shutdown_tx,
             })

--- a/irc/src/adapter.rs
+++ b/irc/src/adapter.rs
@@ -89,9 +89,9 @@ impl PlatformAdapter for IrcAdapter {
 
             Ok(PlatformHandle {
                 id: platform_id,
-                sender: Box::new(sender),
-                user_lister: Box::new(Arc::clone(&lister)),
-                channel_lister: Box::new(lister),
+                sender: Arc::new(sender),
+                user_lister: Arc::clone(&lister) as Arc<dyn harmony_core::ListUsers>,
+                channel_lister: lister,
                 shutdown_tx,
             })
         })

--- a/irc/src/sender.rs
+++ b/irc/src/sender.rs
@@ -1,6 +1,7 @@
 //! Sends bridged messages as IRC PRIVMSG.
 
 use std::fmt::Write as _;
+use std::sync::Arc;
 
 use exn::{Exn, OptionExt as _};
 use harmony_core::{
@@ -47,7 +48,7 @@ fn format_message_from_core(
 impl SendMessage for IrcSender {
     fn send_message<'a>(
         &'a self,
-        message: &'a CoreMessage,
+        message: &'a Arc<CoreMessage>,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
         Box::pin(async {
             let display_name = message

--- a/testing/src/fake_platform.rs
+++ b/testing/src/fake_platform.rs
@@ -68,13 +68,13 @@ impl PlatformAdapter for FakePlatform {
                     tokio::select! {
                         Some(msg) = inject_msg_rx.recv() => {
                             if msg_tx.send((task_id.clone(), msg)).await.is_err() {
-                                log::warn!("fake {}: receiver dropped, stopping", task_id);
+                                log::warn!("fake {task_id}: receiver dropped, stopping");
                                 break;
                             }
                         }
                         Some(event) = inject_event_rx.recv() => {
                             if event_tx.send(event).await.is_err() {
-                                log::warn!("fake {}: receiver dropped, stopping", task_id);
+                                log::warn!("fake {task_id}: receiver dropped, stopping");
                                 break;
                             }
                         }

--- a/testing/src/fake_platform.rs
+++ b/testing/src/fake_platform.rs
@@ -3,8 +3,8 @@
 //! `FakePlatform` implements `PlatformAdapter` so tests can inject
 //! messages/events on one side and assert what comes out the other.
 
-use std::time::Duration;
 use std::sync::Arc;
+use std::time::Duration;
 
 use exn::Exn;
 use harmony_core::{
@@ -88,16 +88,16 @@ impl PlatformAdapter for FakePlatform {
                 captured_tx: self.captured_tx,
             };
 
-            let lister = FakeLister {
+            let lister = Arc::new(FakeLister {
                 channels: self.channels,
                 users: self.users,
-            };
+            });
 
             Ok(PlatformHandle {
                 id,
-                sender: Box::new(sender),
-                user_lister: Box::new(lister.clone()),
-                channel_lister: Box::new(lister),
+                sender: Arc::new(sender),
+                user_lister: Arc::clone(&lister) as Arc<dyn harmony_core::ListUsers>,
+                channel_lister: lister,
                 shutdown_tx,
             })
         })

--- a/testing/src/fake_platform.rs
+++ b/testing/src/fake_platform.rs
@@ -4,6 +4,7 @@
 //! messages/events on one side and assert what comes out the other.
 
 use std::time::Duration;
+use std::sync::Arc;
 
 use exn::Exn;
 use harmony_core::{
@@ -20,7 +21,7 @@ pub struct FakePlatform {
     id: PlatformId,
     inject_msg_rx: mpsc::Receiver<PlatformMessage>,
     inject_event_rx: mpsc::Receiver<MetaEvent>,
-    captured_tx: mpsc::UnboundedSender<CoreMessage>,
+    captured_tx: mpsc::UnboundedSender<Arc<CoreMessage>>,
     channels: Vec<PlatformChannel>,
     users: Vec<PlatformUser>,
 }
@@ -104,15 +105,15 @@ impl PlatformAdapter for FakePlatform {
 }
 
 struct FakeSender {
-    captured_tx: mpsc::UnboundedSender<CoreMessage>,
+    captured_tx: mpsc::UnboundedSender<Arc<CoreMessage>>,
 }
 
 impl SendMessage for FakeSender {
     fn send_message<'a>(
         &'a self,
-        message: &'a CoreMessage,
+        message: &'a Arc<CoreMessage>,
     ) -> BoxFuture<'a, Result<(), Exn<HarmonyError>>> {
-        let _ = self.captured_tx.send(message.clone());
+        let _ = self.captured_tx.send(Arc::clone(message));
         Box::pin(async { Ok(()) })
     }
 }
@@ -142,7 +143,7 @@ pub struct FakeControl {
     platform_id: PlatformId,
     inject_msg_tx: mpsc::Sender<PlatformMessage>,
     inject_event_tx: mpsc::Sender<MetaEvent>,
-    captured_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<CoreMessage>>,
+    captured_rx: tokio::sync::Mutex<mpsc::UnboundedReceiver<Arc<CoreMessage>>>,
 }
 
 impl FakeControl {
@@ -165,7 +166,7 @@ impl FakeControl {
     }
 
     /// Wait for the next relayed message, returning `None` on timeout.
-    pub async fn next_message(&self, timeout: Duration) -> Option<CoreMessage> {
+    pub async fn next_message(&self, timeout: Duration) -> Option<Arc<CoreMessage>> {
         let mut rx = self.captured_rx.lock().await;
         tokio::time::timeout(timeout, rx.recv())
             .await


### PR DESCRIPTION
Closes #1 

The problem:
When building the `serenity::Client` struct, it clones the msg_tx and event_tx and passes them to its Http client. Since we reuse that Http client as part of the DiscordSender, the Senders are being kept alive even once the Serenity client shuts down, preventing `core` from exiting gracefully.

The fix:
The issue here is shared ownership between Core and the adapters. In this case, we avoid it by using channels instead of passing the DiscordSender. We can still pass it directly for listing channels and users as these are consumed by the Core on startup.

I guess we should consider always using channels in Core for send_message since this better separates adapters from Core, or maybe there is a way to represent this constraint with the type system?