### PR TITLE
feat: quote awareness

### DIFF
--- a/app/tests/relay.rs
+++ b/app/tests/relay.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use harmony_testing::{
     CoreMessageSegment, PlatformChannel, PlatformId, PlatformMessage, PlatformMessageSegment,
-    PlatformUser, expect, expect_none, send, test_world,
+    PlatformUser, expect, expect_none, rope_to_text, send, test_world,
 };
 
 #[tokio::test]
@@ -203,6 +203,256 @@ async fn mention_segment_preserved_in_core_message() {
     assert!(matches!(&msg.content[0], CoreMessageSegment::Text(t) if t == "ping "));
     assert!(
         matches!(&msg.content[1], CoreMessageSegment::Mention(u) if u.display_name() == Some("bob"))
+    );
+
+    ctx.shutdown().await;
+}
+
+// --- MessageRef / reply tests ---
+
+fn pm(platform: &str, author: &str, channel: &str, text: &str) -> PlatformMessage {
+    inject_msg(
+        platform,
+        author,
+        channel,
+        vec![PlatformMessageSegment::Text(text.to_owned())],
+    )
+}
+
+#[tokio::test]
+async fn message_ref_resolved_and_relayed() {
+    // Bob is correlated across alpha + beta. Alice on alpha sends a reply
+    // to a prior bob message; beta receives the reply with bob's beta
+    // identity rejoined to the inner ref's author.
+    // Both bob identities share the same display name (= identity, given
+    // the test world's default), so auto-correlation links them.
+    let ctx = test_world! {
+        platforms {
+            alpha: ["#general"],
+            beta: ["#general"],
+        }
+        users {
+            bob: { alpha: "bob", beta: "bob" },
+        }
+    }
+    .start()
+    .await;
+
+    let bob_prior = pm("alpha", "bob", "#general", "first");
+
+    ctx.control("alpha")
+        .inject_message(inject_msg(
+            "alpha",
+            "alice",
+            "#general",
+            vec![
+                PlatformMessageSegment::MessageRef(Box::new(bob_prior)),
+                PlatformMessageSegment::Text("agreed".to_owned()),
+            ],
+        ))
+        .await;
+
+    let msg = ctx
+        .control("beta")
+        .next_message(Duration::from_secs(2))
+        .await
+        .expect("beta should receive a message");
+
+    assert_eq!(msg.content.len(), 2);
+    let CoreMessageSegment::MessageRef(inner) = &msg.content[0] else {
+        panic!("expected MessageRef, got {:?}", &msg.content[0]);
+    };
+    let inner_author = &inner.author;
+    let beta_alias = inner_author
+        .get_platform_user(&PlatformId::new("beta"))
+        .expect("inner ref author should have beta alias via auto-correlation");
+    assert_eq!(beta_alias.id, "bob");
+    assert_eq!(rope_to_text(&inner.content), "first");
+
+    assert!(matches!(&msg.content[1], CoreMessageSegment::Text(t) if t == "agreed"));
+
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn message_ref_unknown_author_fabricated() {
+    // The ref's author is unknown to the bridge: it must survive as a
+    // fabricated single-platform CoreUser carrying the platform display_name.
+    let ctx = test_world! {
+        platforms {
+            alpha: ["#general"],
+            beta: ["#general"],
+        }
+    }
+    .start()
+    .await;
+
+    let ghost_msg = pm("alpha", "ghost", "#general", "boo");
+
+    ctx.control("alpha")
+        .inject_message(inject_msg(
+            "alpha",
+            "alice",
+            "#general",
+            vec![
+                PlatformMessageSegment::MessageRef(Box::new(ghost_msg)),
+                PlatformMessageSegment::Text("ok".to_owned()),
+            ],
+        ))
+        .await;
+
+    let msg = ctx
+        .control("beta")
+        .next_message(Duration::from_secs(2))
+        .await
+        .expect("beta should receive a message");
+
+    let CoreMessageSegment::MessageRef(inner) = &msg.content[0] else {
+        panic!("expected MessageRef, got {:?}", &msg.content[0]);
+    };
+    assert_eq!(inner.author.display_name(), Some("ghost"));
+    assert!(
+        inner
+            .author
+            .get_platform_user(&PlatformId::new("alpha"))
+            .is_some(),
+        "fabricated user should retain its source-platform alias",
+    );
+    assert!(
+        inner
+            .author
+            .get_platform_user(&PlatformId::new("beta"))
+            .is_none(),
+        "fabricated user should NOT have a beta alias (no auto-correlation)",
+    );
+
+    ctx.shutdown().await;
+}
+
+#[tokio::test]
+async fn multiple_refs_in_rope_relayed() {
+    // Non-leading refs survive end-to-end with surrounding text segments.
+    let ctx = test_world! {
+        platforms {
+            alpha: ["#general"],
+            beta: ["#general"],
+        }
+    }
+    .start()
+    .await;
+
+    let m1 = pm("alpha", "a1", "#general", "msg1");
+    let m2 = pm("alpha", "a2", "#general", "msg2");
+
+    ctx.control("alpha")
+        .inject_message(inject_msg(
+            "alpha",
+            "alice",
+            "#general",
+            vec![
+                PlatformMessageSegment::Text("see ".to_owned()),
+                PlatformMessageSegment::MessageRef(Box::new(m1)),
+                PlatformMessageSegment::Text(" and ".to_owned()),
+                PlatformMessageSegment::MessageRef(Box::new(m2)),
+            ],
+        ))
+        .await;
+
+    let msg = ctx
+        .control("beta")
+        .next_message(Duration::from_secs(2))
+        .await
+        .expect("beta should receive a message");
+
+    assert_eq!(msg.content.len(), 4);
+    assert!(matches!(&msg.content[0], CoreMessageSegment::Text(t) if t == "see "));
+    assert!(matches!(&msg.content[1], CoreMessageSegment::MessageRef(_)));
+    assert!(matches!(&msg.content[2], CoreMessageSegment::Text(t) if t == " and "));
+    assert!(matches!(&msg.content[3], CoreMessageSegment::MessageRef(_)));
+
+    ctx.shutdown().await;
+}
+
+fn build_ref_chain(depth: usize) -> PlatformMessage {
+    let mut current = inject_msg(
+        "alpha",
+        &format!("author{depth}"),
+        "#general",
+        vec![PlatformMessageSegment::Text("leaf".to_owned())],
+    );
+    for level in (1..depth).rev() {
+        current = inject_msg(
+            "alpha",
+            &format!("author{level}"),
+            "#general",
+            vec![
+                PlatformMessageSegment::MessageRef(Box::new(current)),
+                PlatformMessageSegment::Text(format!("body{level}")),
+            ],
+        );
+    }
+    current
+}
+
+#[tokio::test]
+async fn deeply_nested_refs_truncate_at_4() {
+    // Build a chain of 7 nested PlatformMessages (each referencing the next).
+    // Core conversion must preserve refs at quote levels 1..=4 and replace
+    // the level-5 ref with a `> ...` truncation marker living inside the
+    // depth-4 ref's content.
+    let ctx = test_world! {
+        platforms {
+            alpha: ["#general"],
+            beta: ["#general"],
+        }
+    }
+    .start()
+    .await;
+
+    let depth7 = build_ref_chain(7);
+    ctx.control("alpha").inject_message(depth7).await;
+
+    let msg = ctx
+        .control("beta")
+        .next_message(Duration::from_secs(2))
+        .await
+        .expect("beta should receive a message");
+
+    // The top-level message is author1 (no `>` prefix); refs at quote
+    // levels 1..=4 hold author2..=author5. Author6 (would-be quote level 5)
+    // is truncated.
+    assert_eq!(msg.author.display_name(), Some("author1"));
+    let mut cursor = &msg.content;
+    for level in 1..=4 {
+        let ref_seg = cursor
+            .iter()
+            .find_map(|s| match s {
+                CoreMessageSegment::MessageRef(inner) => Some(inner.as_ref()),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected MessageRef at quote level {level}"));
+        let expected = format!("author{}", level + 1);
+        assert_eq!(
+            ref_seg.author.display_name(),
+            Some(expected.as_str()),
+            "quote level {level} author mismatch",
+        );
+        cursor = &ref_seg.content;
+    }
+
+    let any_ref = cursor
+        .iter()
+        .any(|s| matches!(s, CoreMessageSegment::MessageRef(_)));
+    assert!(
+        !any_ref,
+        "depth-5 MessageRef should have been truncated, not preserved",
+    );
+    let truncated = cursor
+        .iter()
+        .any(|s| matches!(s, CoreMessageSegment::Text(t) if t.contains("> ...")));
+    assert!(
+        truncated,
+        "depth-5 ref should be replaced by a `> ...` truncation marker; got: {cursor:?}",
     );
 
     ctx.shutdown().await;

--- a/core/src/messages/core_message.rs
+++ b/core/src/messages/core_message.rs
@@ -14,6 +14,7 @@ pub struct CoreMessage {
 pub enum CoreMessageSegment {
     Text(String),
     Mention(CoreUser),
+    MessageRef(Box<CoreMessage>),
 }
 
 /// A rope of message segments.

--- a/core/src/messages/platform_message.rs
+++ b/core/src/messages/platform_message.rs
@@ -16,6 +16,7 @@ pub enum PlatformMessageSegment {
     // FIXME: `String` here is the platform-specific snowflake ID for the user
     // being mentioned. We ought have it properly typed.
     Mention(String),
+    MessageRef(Box<PlatformMessage>),
 }
 
 /// A rope of message segments.

--- a/core/src/run.rs
+++ b/core/src/run.rs
@@ -1,11 +1,11 @@
 //! Lifecycle: start adapters, discover data, relay messages, handle events.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use exn::{Exn, ResultExt as _};
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::error::HarmonyError;
@@ -14,8 +14,9 @@ const MAX_SEND_RETRIES: u32 = 3;
 const RETRY_BACKOFF: Duration = Duration::from_millis(200);
 use crate::{
     Channels, CoreChannel, CoreMessage, CoreMessageRope, CoreMessageSegment, CoreUser,
-    DEFAULT_CHANNEL_BUFFER, ListChannels, ListUsers, MetaEvent, Peers, PlatformAdapter, PlatformId,
-    PlatformMessage, PlatformMessageRope, PlatformMessageSegment, PlatformUser, SendMessage, Users,
+    DEFAULT_CHANNEL_BUFFER, ListChannels, ListUsers, MetaEvent, Peered, Peers, PlatformAdapter,
+    PlatformId, PlatformMessage, PlatformMessageRope, PlatformMessageSegment, PlatformUser,
+    SendMessage, Users,
 };
 
 /// A simple context used for dependency injection across core.
@@ -124,7 +125,7 @@ pub async fn run(
                     dispatch(ctx.clone(), &source_id, msg).await;
                 }
                 Some(event) = event_rx.recv() => {
-                    handle_event(ctx.clone(), &event).await;
+                    handle_event(&ctx, &event);
                 }
                 else => break,
             }
@@ -134,18 +135,26 @@ pub async fn run(
     Ok(AdapterHandle { task, shutdown_txs })
 }
 
-async fn platform_to_core_segment(
+/// Maximum quote-nesting depth at which `MessageRef` segments are preserved
+/// during platform→core conversion. Refs deeper than this collapse into a
+/// `Text("> ...")` truncation marker (see `platform_to_core_segment`).
+const MAX_REF_DEPTH: u8 = 4;
+
+fn platform_to_core_segment(
     ctx: &CoreCtx,
     source_id: &PlatformId,
     segment: &PlatformMessageSegment,
+    depth: u8,
 ) -> CoreMessageSegment {
     match segment {
         PlatformMessageSegment::Text(text) => CoreMessageSegment::Text(text.clone()),
         PlatformMessageSegment::Mention(id) => {
-            let mentioned_user = {
-                let users = ctx.users.read().await;
-                users.find(source_id, id).cloned()
-            };
+            let mentioned_user = ctx
+                .users
+                .read()
+                .expect("users lock poisoned")
+                .find(source_id, id)
+                .cloned();
 
             mentioned_user.map_or_else(
                 || {
@@ -155,18 +164,56 @@ async fn platform_to_core_segment(
                 CoreMessageSegment::Mention,
             )
         }
+        PlatformMessageSegment::MessageRef(ref_msg) => {
+            if depth >= MAX_REF_DEPTH {
+                // Surrounding `\n` so the marker stays on its own line in the
+                // parent's rendered rope (mirrors how a real `MessageRef`
+                // renders).
+                return CoreMessageSegment::Text("\n> ...\n".to_owned());
+            }
+
+            let core_channel = ctx
+                .channels
+                .read()
+                .expect("channels lock poisoned")
+                .find(source_id, &ref_msg.channel.id)
+                .cloned()
+                .unwrap_or_else(|| {
+                    CoreChannel::from_single_alias(source_id.clone(), ref_msg.channel.clone())
+                });
+
+            let core_author = ctx
+                .users
+                .read()
+                .expect("users lock poisoned")
+                .find(source_id, &ref_msg.author.id)
+                .cloned()
+                .unwrap_or_else(|| {
+                    CoreUser::from_single_alias(source_id.clone(), ref_msg.author.clone())
+                });
+
+            let core_content =
+                platform_to_core_message(ctx, source_id, &ref_msg.content, depth + 1);
+
+            CoreMessageSegment::MessageRef(Box::new(CoreMessage {
+                author: core_author,
+                channel: core_channel,
+                content: core_content,
+            }))
+        }
     }
 }
 
-async fn platform_to_core_message(
+fn platform_to_core_message(
     ctx: &CoreCtx,
     source_id: &PlatformId,
-    msg: PlatformMessageRope,
+    msg: &PlatformMessageRope,
+    depth: u8,
 ) -> CoreMessageRope {
     let mut core_msg = CoreMessageRope::new();
 
-    for segment in &msg {
-        core_msg.push(platform_to_core_segment(ctx, source_id, segment).await);
+    for segment in msg {
+        core_msg.push(platform_to_core_segment(ctx, source_id, segment, depth));
     }
 
     core_msg
@@ -174,10 +221,12 @@ async fn platform_to_core_message(
 
 /// Dispatches a platform message to all the registered platforms.
 async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessage) {
-    let core_channel = {
-        let ch = ctx.channels.read().await;
-        ch.find(source_id, &msg.channel.id).cloned()
-    };
+    let core_channel = ctx
+        .channels
+        .read()
+        .expect("channels lock poisoned")
+        .find(source_id, &msg.channel.id)
+        .cloned();
 
     let Some(core_channel) = core_channel else {
         log::debug!("{source_id}: no route for channel {}", msg.channel.id);
@@ -185,14 +234,14 @@ async fn dispatch(ctx: Arc<CoreCtx>, source_id: &PlatformId, msg: PlatformMessag
     };
 
     let core_author = {
-        let mut u = ctx.users.write().await;
+        let mut u = ctx.users.write().expect("users lock poisoned");
         resolve_or_register(&mut u, source_id, &msg.author)
     };
 
     let core_msg = CoreMessage {
         author: core_author,
         channel: core_channel.clone(),
-        content: platform_to_core_message(&ctx, source_id, msg.content).await,
+        content: platform_to_core_message(&ctx, source_id, &msg.content, 0),
     };
 
     for platform in core_channel.alias.keys() {
@@ -274,15 +323,19 @@ fn resolve_or_register(
 }
 
 /// Handle a runtime event by directly updating the in-memory collections.
-async fn handle_event(ctx: Arc<CoreCtx>, event: &MetaEvent) {
-    let users = ctx.users.clone();
-    let channels = ctx.channels.clone();
+fn handle_event(ctx: &CoreCtx, event: &MetaEvent) {
     match event {
         MetaEvent::UserJoined { user, .. } | MetaEvent::UserUpdated { user, .. } => {
-            users.write().await.upsert(user.clone());
+            ctx.users
+                .write()
+                .expect("users lock poisoned")
+                .upsert(user.clone());
         }
         MetaEvent::UserLeft { platform, id } => {
-            users.write().await.detach(platform, id);
+            ctx.users
+                .write()
+                .expect("users lock poisoned")
+                .detach(platform, id);
         }
         MetaEvent::UserRenamed {
             platform,
@@ -290,24 +343,32 @@ async fn handle_event(ctx: Arc<CoreCtx>, event: &MetaEvent) {
             new_id,
             new_display_name,
         } => {
-            users
-                .write()
-                .await
-                .rename(platform, old_id, new_id, new_display_name.clone());
+            ctx.users.write().expect("users lock poisoned").rename(
+                platform,
+                old_id,
+                new_id,
+                new_display_name.clone(),
+            );
         }
         MetaEvent::UsersDiscovered {
             users: new_users, ..
         } => {
-            let mut u = users.write().await;
+            let mut u = ctx.users.write().expect("users lock poisoned");
             for user in new_users {
                 u.upsert(user.clone());
             }
         }
         MetaEvent::ChannelCreated { channel, .. } | MetaEvent::ChannelUpdated { channel, .. } => {
-            channels.write().await.upsert(channel.clone());
+            ctx.channels
+                .write()
+                .expect("channels lock poisoned")
+                .upsert(channel.clone());
         }
         MetaEvent::ChannelDeleted { platform, id } => {
-            channels.write().await.detach(platform, id);
+            ctx.channels
+                .write()
+                .expect("channels lock poisoned")
+                .detach(platform, id);
         }
     }
 }

--- a/discord/src/convert.rs
+++ b/discord/src/convert.rs
@@ -72,6 +72,13 @@ pub fn discord_to_core(msg: &SerenityMessage, platform_id: &PlatformId) -> Platf
         .or_else(|| msg.author.global_name.clone())
         .or_else(|| Some(msg.author.name.clone()));
 
+    let mut rope = PlatformMessageRope::new();
+    if let Some(referenced) = msg.referenced_message.as_deref() {
+        let ref_msg = discord_to_core(referenced, platform_id);
+        rope.push(PlatformMessageSegment::MessageRef(Box::new(ref_msg)));
+    }
+    rope.extend(parse_message(&content));
+
     PlatformMessage {
         author: PlatformUser {
             platform: platform_id.clone(),
@@ -84,6 +91,6 @@ pub fn discord_to_core(msg: &SerenityMessage, platform_id: &PlatformId) -> Platf
             id: msg.channel_id.get().to_string(),
             name: msg.channel_id.get().to_string(),
         },
-        content: parse_message(&content),
+        content: rope,
     }
 }

--- a/discord/src/sender.rs
+++ b/discord/src/sender.rs
@@ -77,26 +77,42 @@ impl DiscordSender {
     }
 }
 
-fn format_message_from_core(platform_id: &PlatformId, message: &CoreMessage) -> String {
-    message
-        .content
+fn render_msg(platform_id: &PlatformId, msg: &CoreMessage) -> String {
+    msg.content
         .iter()
-        .fold(String::new(), |mut result, segment| {
-            match segment {
-                CoreMessageSegment::Text(text) => {
-                    result.push_str(text);
-                }
-                CoreMessageSegment::Mention(core_user) => {
-                    if let Some(pu) = core_user.get_platform_user(platform_id) {
-                        result.push_str(&format_mention(&pu.id));
+        .fold(String::new(), |mut acc, seg| {
+            match seg {
+                CoreMessageSegment::Text(text) => acc.push_str(text),
+                CoreMessageSegment::Mention(user) => {
+                    if let Some(pu) = user.get_platform_user(platform_id) {
+                        acc.push_str(&format_mention(&pu.id));
                     } else {
-                        let name = core_user.display_name().unwrap_or("unknown");
-                        let _ = write!(result, "@{name}");
+                        let name = user.display_name().unwrap_or("unknown");
+                        let _ = write!(acc, "@{name}");
                     }
                 }
+                CoreMessageSegment::MessageRef(inner) => {
+                    let body = render_msg(platform_id, inner);
+                    // Enforce \n before and after so refs in the middle of a rope
+                    // don't blend into surrounding Text segments
+                    let _ = write!(acc, "\nQuoting ");
+                    if let Some(pu) = inner.author.get_platform_user(platform_id) {
+                        acc.push_str(&format_mention(&pu.id));
+                    } else {
+                        let name = inner.author.display_name().unwrap_or("unknown");
+                        let _ = write!(acc, "@{name}");
+                    }
+                    acc.push(':');
+                    for line in body.lines() {
+                        let _ = write!(acc, "\n> {line}");
+                    }
+                    acc.push('\n');
+                }
             }
-            result
+            acc
         })
+        .trim_matches('\n')
+        .to_owned()
 }
 
 impl SendMessage for DiscordSender {
@@ -131,7 +147,7 @@ impl SendMessage for DiscordSender {
                 .or_else(|| message.author.avatar_url());
 
             let mut exec = ExecuteWebhook::new()
-                .content(format_message_from_core(&self.platform_id, message))
+                .content(render_msg(&self.platform_id, message))
                 .username(display_name);
             if let Some(url) = avatar_url {
                 exec = exec.avatar_url(url);
@@ -162,5 +178,97 @@ impl ListChannels for DiscordSender {
                 crate::fetch::fetch_guild_data(&self.http, &self.platform_id).await?;
             Ok(channels)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmony_core::{CoreChannel, CoreUser, Peered};
+
+    fn pid() -> PlatformId {
+        PlatformId::new("discord")
+    }
+
+    fn user(name: &str) -> CoreUser {
+        CoreUser::from_single_alias(
+            pid(),
+            PlatformUser {
+                platform: pid(),
+                id: name.to_owned(),
+                display_name: Some(name.to_owned()),
+                avatar_url: None,
+            },
+        )
+    }
+
+    fn channel() -> CoreChannel {
+        CoreChannel::from_single_alias(
+            pid(),
+            PlatformChannel {
+                platform: pid(),
+                id: "1".to_owned(),
+                name: "#test".to_owned(),
+            },
+        )
+    }
+
+    fn msg(author: &str, content: Vec<CoreMessageSegment>) -> CoreMessage {
+        CoreMessage {
+            author: user(author),
+            channel: channel(),
+            content,
+        }
+    }
+
+    #[test]
+    fn netiquette_layout_renders_quoted_chain() {
+        let alice = msg(
+            "alice",
+            vec![CoreMessageSegment::Text("67 67 67".to_owned())],
+        );
+        let bob = msg(
+            "bob",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(alice)),
+                CoreMessageSegment::Text("Haha".to_owned()),
+            ],
+        );
+        let charlie = msg(
+            "charlie",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(bob)),
+                CoreMessageSegment::Text("What am I looking at?".to_owned()),
+            ],
+        );
+        let mine = msg(
+            "me",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(charlie)),
+                CoreMessageSegment::Text("It's a joke".to_owned()),
+            ],
+        );
+
+        let rendered = render_msg(&pid(), &mine);
+        let expected = "\
+Quoting <@charlie>:
+> Quoting <@bob>:
+> > Quoting <@alice>:
+> > > 67 67 67
+> > Haha
+> What am I looking at?
+It's a joke";
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn ref_only_message_has_no_trailing_blank() {
+        // A message whose rope is just a MessageRef should render as the
+        // quote alone, with no leading/trailing blank line.
+        let alice = msg("alice", vec![CoreMessageSegment::Text("hi".to_owned())]);
+        let mine = msg("me", vec![CoreMessageSegment::MessageRef(Box::new(alice))]);
+
+        let rendered = render_msg(&pid(), &mine);
+        assert_eq!(rendered, "Quoting <@alice>:\n> hi");
     }
 }

--- a/irc/src/sender.rs
+++ b/irc/src/sender.rs
@@ -16,32 +16,51 @@ pub struct IrcSender {
     pub(crate) platform_id: PlatformId,
 }
 
+fn render_msg(platform_id: &PlatformId, msg: &CoreMessage) -> String {
+    msg.content
+        .iter()
+        .fold(String::new(), |mut acc, seg| {
+            match seg {
+                CoreMessageSegment::Text(text) => acc.push_str(text),
+                CoreMessageSegment::Mention(user) => {
+                    if let Some(pu) = user.get_platform_user(platform_id) {
+                        acc.push_str(&format_mention(&pu.id));
+                    } else {
+                        let name = user.display_name().unwrap_or("unknown");
+                        let _ = write!(acc, "@{name}");
+                    }
+                }
+                CoreMessageSegment::MessageRef(inner) => {
+                    let body = render_msg(platform_id, inner);
+                    let _ = write!(acc, "\nQuoting ");
+                    if let Some(pu) = inner.author.get_platform_user(platform_id) {
+                        acc.push_str(&format_mention(&pu.id));
+                    } else {
+                        let name = inner.author.display_name().unwrap_or("unknown");
+                        let _ = write!(acc, "@{name}");
+                    }
+                    acc.push(':');
+                    for line in body.lines() {
+                        let _ = write!(acc, "\n> {line}");
+                    }
+                    acc.push('\n');
+                }
+            }
+            acc
+        })
+        .trim_matches('\n')
+        .to_owned()
+}
+
 fn format_message_from_core(
     platform_id: &PlatformId,
     display_name: &str,
     message: &CoreMessage,
-) -> String {
-    let result = message
-        .content
-        .iter()
-        .fold(String::new(), |mut result, segment| {
-            match segment {
-                CoreMessageSegment::Text(text) => {
-                    result.push_str(text);
-                }
-                CoreMessageSegment::Mention(core_user) => {
-                    if let Some(pu) = core_user.get_platform_user(platform_id) {
-                        result.push_str(&format_mention(&pu.id));
-                    } else {
-                        let name = core_user.display_name().unwrap_or("unknown");
-                        let _ = write!(result, "@{name}");
-                    }
-                }
-            }
-            result
-        });
-
-    format!("<{display_name}> {result}")
+) -> Vec<String> {
+    render_msg(platform_id, message)
+        .split('\n')
+        .filter_map(|l| (!l.is_empty()).then(|| format!("<{display_name}> {l}")))
+        .collect()
 }
 
 impl SendMessage for IrcSender {
@@ -64,11 +83,108 @@ impl SendMessage for IrcSender {
                     HarmonyError::send("no channel alias for this platform").permanent()
                 })?;
 
-            let text = format_message_from_core(&self.platform_id, display_name, message);
-            self.inner
-                .send_privmsg(&channel.id, text)
-                .map_err(|e| HarmonyError::send(e.to_string()).temporary())?;
+            for line in format_message_from_core(&self.platform_id, display_name, message) {
+                self.inner
+                    .send_privmsg(&channel.id, line)
+                    .map_err(|e| HarmonyError::send(e.to_string()).temporary())?;
+            }
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use harmony_core::{CoreChannel, CoreUser, Peered, PlatformChannel, PlatformUser};
+
+    fn pid() -> PlatformId {
+        PlatformId::new("irc")
+    }
+
+    fn user(name: &str) -> CoreUser {
+        CoreUser::from_single_alias(
+            pid(),
+            PlatformUser {
+                platform: pid(),
+                id: name.to_owned(),
+                display_name: Some(name.to_owned()),
+                avatar_url: None,
+            },
+        )
+    }
+
+    fn channel() -> CoreChannel {
+        CoreChannel::from_single_alias(
+            pid(),
+            PlatformChannel {
+                platform: pid(),
+                id: "#test".to_owned(),
+                name: "#test".to_owned(),
+            },
+        )
+    }
+
+    fn msg(author: &str, content: Vec<CoreMessageSegment>) -> CoreMessage {
+        CoreMessage {
+            author: user(author),
+            channel: channel(),
+            content,
+        }
+    }
+
+    #[test]
+    fn netiquette_layout_emits_one_privmsg_per_quote_line() {
+        let alice = msg(
+            "alice",
+            vec![CoreMessageSegment::Text("67 67 67".to_owned())],
+        );
+        let bob = msg(
+            "bob",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(alice)),
+                CoreMessageSegment::Text("Haha".to_owned()),
+            ],
+        );
+        let charlie = msg(
+            "charlie",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(bob)),
+                CoreMessageSegment::Text("What am I looking at?".to_owned()),
+            ],
+        );
+        let mine = msg(
+            "me",
+            vec![
+                CoreMessageSegment::MessageRef(Box::new(charlie)),
+                CoreMessageSegment::Text("It's a joke".to_owned()),
+            ],
+        );
+
+        let lines = format_message_from_core(&pid(), "me", &mine);
+        assert_eq!(
+            lines,
+            vec![
+                "<me> Quoting @charlie:".to_owned(),
+                "<me> > Quoting @bob:".to_owned(),
+                "<me> > > Quoting @alice:".to_owned(),
+                "<me> > > > 67 67 67".to_owned(),
+                "<me> > > Haha".to_owned(),
+                "<me> > What am I looking at?".to_owned(),
+                "<me> It's a joke".to_owned(),
+            ],
+        );
+    }
+
+    #[test]
+    fn ref_only_message_emits_no_trailing_empty_privmsg() {
+        let alice = msg("alice", vec![CoreMessageSegment::Text("hi".to_owned())]);
+        let mine = msg("me", vec![CoreMessageSegment::MessageRef(Box::new(alice))]);
+
+        let lines = format_message_from_core(&pid(), "me", &mine);
+        assert_eq!(
+            lines,
+            vec!["<me> Quoting @alice:".to_owned(), "<me> > hi".to_owned()],
+        );
     }
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -19,6 +19,10 @@ pub use fake_platform::{FakeControl, FakePlatform, FakePlatformBuilder};
 pub use world::{PlatformSpec, TestWorld, TestWorldBuilder, UserSpec};
 
 /// Render a [`CoreMessageRope`] as a plain string, formatting mentions as `@name`.
+///
+/// `MessageRef` segments recurse into their referenced message and surface as
+/// `[> @author: <inner>]` so deeply-nested refs remain visible in test
+/// assertion strings.
 pub fn rope_to_text(rope: &[CoreMessageSegment]) -> String {
     use std::fmt::Write as _;
 
@@ -27,6 +31,14 @@ pub fn rope_to_text(rope: &[CoreMessageSegment]) -> String {
             CoreMessageSegment::Text(t) => result.push_str(t),
             CoreMessageSegment::Mention(u) => {
                 let _ = write!(result, "@{}", u.display_name().unwrap_or("unknown"));
+            }
+            CoreMessageSegment::MessageRef(inner) => {
+                let _ = write!(
+                    result,
+                    "[> @{}: {}]",
+                    inner.author.display_name().unwrap_or("unknown"),
+                    rope_to_text(&inner.content),
+                );
             }
         }
         result


### PR DESCRIPTION
# What ?

The point is to support quoting a message and it being rendered correctly

# Why ?

It's useful and supported by pretty much every messaging platform.

# How ?

Basically, add a MessageRef MessageSegment (same kind of thing as mention), that has a reference to another message. We can recursively then follow the message ref and render the message ref-ed by the MessageRef and adding quoting markings like `> ` before every line.

# Additional information

It fulfills the "reply" usecase, as replies are basically a quotation at the beginning of your answer.

Closes #12
Closes #32 (side effect of impl)